### PR TITLE
Support colors

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -108,6 +108,7 @@ let print = () => {
 
     console.log(formatTableRow(`${chalk['bold']('--help')}`, `Show help`))
     console.log(formatTableRow(`${chalk['bold']('--version')}`, `Print version`))
+    console.log(formatTableRow(`${chalk['bold']('--disable-styles')}`, `Disable HTML styles`))
 }
 
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -94,11 +94,79 @@ let parseTimecode = (timecode) => {
 }
 
 /**
+ * Checks if a color is not white or black
+ * @param {String} color - Color format string
+ * @return {Boolean} Whether the color is valid
+ */
+let isValidColor = (color) => {
+    return color !== '#000000' && color !== '#ffffff'
+}
+
+/**
+ * Renders a single line of text with a style
+ * @param {String} line - Text
+ * @param {Object} style - Style definition
+ * @return {String} Formatted text
+ */
+let renderLineWithStyle = (text, style) => {
+    let prefix = ''
+    let suffix = ''
+
+    if ('tts:color' in style) {
+        const color = style['tts:color'].toLowerCase()
+
+        // Don't force white or black, allow the user to use a custom color in their video player if they wish
+        if (isValidColor(color)) {
+            prefix = '<font color="' + color + '">'
+            suffix = '</font>'
+        }
+    }
+
+    return prefix + text + suffix
+}
+
+/**
+ * Renders a single paragraph
+ * @param {Object} entry - Paragraph object
+ * @param {Array} styles - Style definitions
+ * @return {String} Rendered paragraph
+ */
+let renderParagraph = (entry, styles) => {
+    const metadata = entry['tt:p']
+
+    let baseStyle = {}
+    if ('style' in metadata) {
+        baseStyle = styles[metadata['style']]
+    }
+
+    let lines = []
+
+    // Get raw text paragraphs
+    const textList = entry['tt:span'] instanceof Array ? entry['tt:span'] : [entry['tt:span']]
+
+    textList.forEach((text) => {
+        const rawText = text['tt:span']
+
+        let spanStyle = {}
+        if ('style' in text['tt:p']) {
+            spanStyle = styles[text['tt:p']['style']]
+        }
+
+        let fullStyle = { ...baseStyle, ...spanStyle }
+
+        lines.push(renderLineWithStyle(rawText, fullStyle))
+    })
+
+    return lines.join(os.EOL)
+}
+
+/**
  * Render subtitle paragraph list into proper SRT (SubRip) subtitle format
  * @param {Array} paragraphList - Subtitle paragraph list
+ * @param {Object} styles - Style definitions
  * @return {String} SubRip Subtitle
  */
-let renderSrt = (paragraphList) => {
+let renderSrt = (paragraphList, styles) => {
     logger.debug('renderSrt')
 
     const entryList = []
@@ -107,8 +175,6 @@ let renderSrt = (paragraphList) => {
     paragraphList.forEach((entry) => {
         // Get raw metadata,text paragraphs
         const metadata = entry['tt:p']
-        // Get raw text paragraphs
-        const textList = entry['tt:span'] instanceof Array ? entry['tt:span'] : [entry['tt:span']]
 
         const begin = parseTimecode(metadata['begin'])
         const end = parseTimecode(metadata['end'])
@@ -116,7 +182,7 @@ let renderSrt = (paragraphList) => {
         entryList.push(entryCount)
         entryList.push(`${begin} --> ${end}`)
 
-        entryList.push(textList.map(text => text['tt:span']).join(os.EOL) + os.EOL)
+        entryList.push(renderParagraph(entry, styles) + os.EOL)
 
         entryCount++
     })
@@ -150,7 +216,19 @@ let parseXmlData = (xmlData) => {
 
     const parsedObject = fastXmlParser.parse(xmlData, options)
 
-    return parsedObject['tt:tt']['tt:body']['tt:div']['tt:p']
+    const paragraphList = parsedObject['tt:tt']['tt:body']['tt:div']['tt:p']
+
+    const head = parsedObject['tt:tt']['tt:head']
+    const styles = {}
+    if ('tt:styling' in head) {
+        const stylesElements = head['tt:styling']['tt:style']
+        stylesElements.forEach((style) => {
+            const element = style['tt:p']
+            styles[element['xml:id']] = element
+        })
+    }
+
+    return { paragraphList, styles }
 }
 
 
@@ -162,7 +240,7 @@ if (require.main === module) {
     let argv
     try {
         argv = minimist(process.argv.slice(2), {
-            'boolean': ['help', 'version']
+            'boolean': ['help', 'version', 'disable-styles']
         })
     } catch (error) {}
 
@@ -182,6 +260,9 @@ if (require.main === module) {
         console.log(messagePrefix, `v${packageJson.version}`)
         process.exit(0)
     }
+
+    // Disable styles
+    const disableStyles = argv['disable-styles']
 
     // Sourcefile
     let argvSourcefile = argv['_'][0]
@@ -208,17 +289,21 @@ if (require.main === module) {
         }
 
         // Parse / Validate XML
-        const entryList = parseXmlData(xmlData)
+        const parsedData = parseXmlData(xmlData)
 
-        if (!entryList) {
+        if (!parsedData) {
             console.log(errorPrefix, '[Error]', 'Malformed XML Subtitle:', argvSourcefile)
             process.exit(1)
 
             return
         }
 
+        if (disableStyles) {
+            parsedData.styles = {}
+        }
+
         // Render SRT
-        const srtText = renderSrt(entryList)
+        const srtText = renderSrt(parsedData.paragraphList, parsedData.styles)
 
         // Write SRT to  disk
         fs.writeFile(targetFile, srtText, 'utf8', (error) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -147,6 +147,10 @@ let renderParagraph = (entry, styles) => {
     textList.forEach((text) => {
         const rawText = text['tt:span']
 
+        // empty space
+        if (!rawText)
+            return;
+
         let spanStyle = {}
         if ('style' in text['tt:p']) {
             spanStyle = styles[text['tt:p']['style']]


### PR DESCRIPTION
This adds initial support for SRT colors, as well as providing a framework for future styling support (such as italics and so on, if EBU-TT supports this).

This can be disabled by the user through the `--disable-styles` option.

This also fixes an issue where 'undefined' would be returned if the subtitle was something like `<tt:span> </tt:span>` (https://github.com/sidneys/xml-to-srt-cli/pull/1/commits/01416e0707f3a05b440a9a5b79a1254d46cfaadb). I would have made a separate pull request for this bugfix, but since this part of the code is modified by this PR, I figured I would just integrate it with this one.