### PR TITLE
Fix millisecond timecode format for srt

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,13 @@ const errorPrefix = chalk['bold']['red'](`[${Object.keys(packageJson['bin'])[0]}
  */
 const defaultTimecodeFormat = 'HH:mm:ss.SSS'
 
+/**
+ * Timecode format for SRT
+ * @constant
+ * @default
+ */
+const srtTimecodeFormat = 'HH:mm:ss,SSS'
+
 
 /**
  * Format timecodes as HH:mm:ss.SSS
@@ -88,7 +95,7 @@ let parseTimecode = (timecode) => {
     }
 
     // Format timecode
-    timecodeFormatted = timecodeMoment.format(defaultTimecodeFormat, { trim: false })
+    timecodeFormatted = timecodeMoment.format(srtTimecodeFormat, { trim: false })
 
     return timecodeFormatted
 }


### PR DESCRIPTION
While some players can understand "ss.SSS", the correct format is "ss,SSS" (some tools break because of this)