### PR TITLE
Unescape html entities

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -21,6 +21,7 @@ appRootPath.setPath(path.join(__dirname, '..'))
 const chalk = require('chalk')
 const logger = require('@sidneys/logger')({ write: true })
 const fastXmlParser = require('fast-xml-parser')
+const he = require('he')
 const minimist = require('minimist')
 const moment = require('moment')
 /* eslint-disable no-unused-vars */
@@ -140,7 +141,9 @@ let parseXmlData = (xmlData) => {
         ignoreNameSpace: false,
         allowBooleanAttributes: false,
         cdataTagName: '__cdata', //default is 'false'
-        cdataPositionChar: '\\c'
+        cdataPositionChar: '\\c',
+        attrValueProcessor: (val, attrName) => he.decode(val, {isAttributeValue: true}),
+        tagValueProcessor : (val, tagName) => he.decode(val)
     }
 
     // Handle invalid XML

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "app-root-path": "^2.0.1",
     "chalk": "^2.4.1",
     "fast-xml-parser": "^3.11.1",
+    "he": "^1.2.0",
     "indent-string": "^3.2.0",
     "minimist": "^1.2.0",
     "moment": "^2.22.2",


### PR DESCRIPTION
Such as replacing `&quot;` to `"`. Some players support html entities, but many don't.

This code is taken from the example code at https://www.npmjs.com/package/fast-xml-parser